### PR TITLE
Enable lexical binding for font-lock-studio.el

### DIFF
--- a/font-lock-studio.el
+++ b/font-lock-studio.el
@@ -1,4 +1,4 @@
-;;; font-lock-studio.el --- interactive debugger for Font Lock keywords.
+;;; font-lock-studio.el --- interactive debugger for Font Lock keywords. -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2017 Anders Lindgren
 


### PR DESCRIPTION
Hi. In Emacs30, not having lexical binding is now a byte compiler warning. I have been using this package for some time with lexical binding enabled and have not encountered any issues nor do I see anything in the code that could cause problems with that.

If any problems do arise, feel free to ping me and I will follow up this PR.
